### PR TITLE
fix gazebo bug

### DIFF
--- a/unitree_guide/CMakeLists.txt
+++ b/unitree_guide/CMakeLists.txt
@@ -56,7 +56,9 @@ if(CATKIN_MAKE)
             controller_manager
             joint_state_controller
             gazebo_ros
-            # gazebo
+            gazebo_msgs
+            gazebo_plugins
+            gazebo_ros_control
         )
     endif()
 


### PR DESCRIPTION
fix #9 #1 
The following four packages will be checked during compilation, and errors will be reported if they are missing: 
* ros-melodic-gazebo-ros-pkgs 
* ros-melodic-gazebo-msgs 
* ros-melodic-gazebo-plugins 
* ros-melodic-gazebo-ros-control
![image](https://user-images.githubusercontent.com/62320343/225827766-3d390a76-4c6b-481c-a17d-a6be05cabeac.png)